### PR TITLE
fix: 当 `BLOG_POST_DIRECTORY` 为空或当前目录时，将会扫描系统根目录中的文件

### DIFF
--- a/__tests__/api/datasource/FileSystemDatasource.test.ts
+++ b/__tests__/api/datasource/FileSystemDatasource.test.ts
@@ -3,7 +3,9 @@ import path from 'node:path'
 import datasource from '@/api/datasource'
 
 test('Test archive list', async () => {
-  const files = glob.globSync(path.join(process.env.BLOG_PATH, process.env.BLOG_HOME_POST_DIRECTORY, '/**/*.{md,mdx}'))
+  const files = glob.globSync('./**/*.{md,mdx}', { cwd: path.resolve(process.env.BLOG_PATH, process.env.BLOG_HOME_POST_DIRECTORY) })
+
+  expect(files.length).toBeGreaterThan(0)
 
   expect((await datasource.getAllHomePosts()).map(v => v.visitPath))
     .toStrictEqual(files.map(v => datasource.resolvePostWebPath(v)))

--- a/scripts/jest.setup.js
+++ b/scripts/jest.setup.js
@@ -3,7 +3,7 @@ import path from "node:path"
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
-const root = path.resolve('__test__/__blog__')
+const root = path.resolve('__tests__/__blog__')
 
 process.env.BLOG_PATH = root
 process.env.BLOG_HOME_POST_DIRECTORY = '_post'

--- a/src/api/datasource/FileSystemDatasource.ts
+++ b/src/api/datasource/FileSystemDatasource.ts
@@ -31,6 +31,9 @@ export default class FileSystemDatasource implements Datasource {
   private readonly homePaths: string[]
   
   public constructor() {
+    if (!fs.existsSync(process.env.BLOG_PATH) || !fs.statSync(process.env.BLOG_PATH).isDirectory()) {
+      throw new Error(`The path '${process.env.BLOG_PATH}' must be a directory. Please check you BLOG_PATH configuration.`)
+    }
     const config = {
       homePostDirectory: process.env.BLOG_HOME_POST_DIRECTORY,
       resourceDirectory: process.env.BLOG_RESOURCE_DIRECTORY,
@@ -51,7 +54,7 @@ export default class FileSystemDatasource implements Datasource {
     let searchGlobs: string[] = []
     pageRelativePath = Array.isArray(pageRelativePath) ? pageRelativePath : [pageRelativePath]
 
-    const append = recursion ? '/**/*.{md,mdx}' : '/*.{md,mdx}'
+    const append = recursion ? './**/*.{md,mdx}' : './*.{md,mdx}'
     for (let root of pageRelativePath) {
       searchGlobs.push(path.join(root, append).replaceAll('\\', '/'))
     }


### PR DESCRIPTION
Changes：

1. 当 `BLOG_POST_DIRECTORY` 为 `./` 或空时，将会扫描系统根目录中的所有文件
2. 当 `BLOG_PATH` 不存在时，抛出异常
3. 修复测试类中的路径错误