### PR TITLE
fix: TOC 点击链接无法跳转

### DIFF
--- a/__tests__/api/markdown-parser/__snapshots__/index.test.tsx.snap
+++ b/__tests__/api/markdown-parser/__snapshots__/index.test.tsx.snap
@@ -2,17 +2,17 @@
 
 exports[`Test md render 1`] = `
 "<div><p>Markdown是一种轻量级的「标记语言」。</p>
-<h2 id="1%20Markdown%E8%AF%AD%E6%B3%95%E6%95%99%E7%A8%8B">1 Markdown语法教程</h2>
-<h3 id="1.1%20%E6%A0%87%E9%A2%98">1.1 标题</h3>
+<h2 id="1-Markdown语法教程">1 Markdown语法教程</h2>
+<h3 id="1.1-标题">1.1 标题</h3>
 <p>不同数量的<code>#</code>可以完成不同的标题.。</p>
-<h3 id="1.2%20%E5%AD%97%E4%BD%93">1.2 字体</h3>
+<h3 id="1.2-字体">1.2 字体</h3>
 <p>粗体、斜体、粗体和斜体，删除线，需要在文字前后加不同的标记符号。如下：</p>
 <p><strong>这个是粗体</strong></p>
 <p><em>这个是斜体</em></p>
 <p><em><strong>这个是粗体加斜体</strong></em></p>
 <p><del>这里是删除线</del></p>
 <p>注：如果想给字体换颜色、字体或者居中显示，需要使用内嵌HTML来实现。</p>
-<h3 id="1.3%20%E6%97%A0%E5%BA%8F%E5%88%97%E8%A1%A8">1.3 无序列表</h3>
+<h3 id="1.3-无序列表">1.3 无序列表</h3>
 <p>无序列表的使用，在符号<code>-</code>后加空格使用。如下：</p>
 <ul>
 <li>无序列表 1</li>
@@ -29,14 +29,14 @@ exports[`Test md render 1`] = `
 </ul>
 </li>
 </ul>
-<h3 id="1.4%20%E6%9C%89%E5%BA%8F%E5%88%97%E8%A1%A8">1.4 有序列表</h3>
+<h3 id="1.4-有序列表">1.4 有序列表</h3>
 <p>有序列表的使用，在数字及符号<code>.</code>后加空格后输入内容，如下：</p>
 <ol>
 <li>有序列表 1</li>
 <li>有序列表 2</li>
 <li>有序列表 3</li>
 </ol>
-<h3 id="1.5%20%E5%BC%95%E7%94%A8">1.5 引用</h3>
+<h3 id="1.5-引用">1.5 引用</h3>
 <p>引用的格式是在符号<code>&gt;</code>后面书写文字。如下：</p>
 <blockquote>
 <p>读一本好书，就是在和高尚的人谈话。 ——歌德</p>
@@ -44,17 +44,17 @@ exports[`Test md render 1`] = `
 <blockquote>
 <p>雇用制度对工人不利，但工人根本无力摆脱这个制度。 ——阮一峰</p>
 </blockquote>
-<h3 id="1.6%20%E9%93%BE%E6%8E%A5">1.6 链接</h3>
+<h3 id="1.6-链接">1.6 链接</h3>
 <p><a href="https://github.com/nextjs-particlex-theme/particlex">particlex</a></p>
-<h3 id="1.7%20%E5%9B%BE%E7%89%87">1.7 图片</h3>
+<h3 id="1.7-图片">1.7 图片</h3>
 <p><img src="/favicon.ico" alt="favicon.ico" loading="lazy"></p>
-<h3 id="1.8%20%E5%88%86%E5%89%B2%E7%BA%BF">1.8 分割线</h3>
+<h3 id="1.8-分割线">1.8 分割线</h3>
 <p>可以在一行中用三个以上的减号来建立一个分隔线，同时需要在分隔线的上面空一行。如下：</p>
 <hr>
-<h3 id="1.9%20%E8%A1%A8%E6%A0%BC">1.9 表格</h3>
+<h3 id="1.9-表格">1.9 表格</h3>
 <p>可以使用冒号来定义表格的对齐方式，如下：</p>
 <table><thead><tr><th align="left">姓名</th><th align="center">年龄</th><th align="right">工作</th></tr></thead><tbody><tr><td align="left">小可爱</td><td align="center">18</td><td align="right">吃可爱多</td></tr><tr><td align="left">小小勇敢</td><td align="center">20</td><td align="right">爬棵勇敢树</td></tr><tr><td align="left">小小小机智</td><td align="center">22</td><td align="right">看一本机智书</td></tr></tbody></table>
-<h3 id="1.10%20%E4%BB%A3%E7%A0%81%E5%9D%97">1.10 代码块</h3>
+<h3 id="1.10-代码块">1.10 代码块</h3>
 <p>如果在一个行内需要引用代码，只要用反引号引起来就好，如下：</p>
 <p>Use the <code>printf()</code> function.</p>
 <p>在需要高亮的代码块的前一行及后一行使用三个反引号，同时<strong>第一行反引号后面表示代码块所使用的语言</strong>，如下：</p>
@@ -70,12 +70,12 @@ exports[`Test md render 1`] = `
 	<span class="hljs-tag">&lt;<span class="hljs-name">world</span>&gt;</span><span class="hljs-tag">&lt;/<span class="hljs-name">world</span>&gt;</span>
 <span class="hljs-tag">&lt;/<span class="hljs-name">hello</span>&gt;</span>
 </div><div>xml</div><div><span title="自动换行"><svg width="18" height="18"><use xlink:href="#wrap-line"></use></svg></span><span title="展开"><svg width="15" height="15"><use xlink:href="#fc-arrows-up-down"></use></svg></span><div title="复制"><svg width="15" height="15"><use xlink:href="#fc-copy"></use></svg></div></div></div></pre>
-<h2 id="2%20%E5%85%B6%E4%BB%96%E8%AF%AD%E6%B3%95">2 其他语法</h2>
-<h3 id="2.1%20HTML">2.1 HTML</h3>
+<h2 id="2-其他语法">2 其他语法</h2>
+<h3 id="2.1-HTML">2.1 HTML</h3>
 <p>支持原生 HTML 语法，请写内联样式，如下：</p>
 <p><span style="display: block; text-align: right; color: orangered;">橙色居右</span>
 <span style="display: block; text-align: center; color: orangered;">橙色居中</span></p>
-<h3 id="Github%20%E8%AD%A6%E5%91%8A">Github 警告</h3>
+<h3 id="Github-警告">Github 警告</h3>
 <blockquote><div class="flex items-center mt-4"><svg width="15" height="15"><use xlink:href="#icon-info"></use></svg><span class="ml-2">Note</span></div><p>Note 123</p>
 </blockquote>
 <blockquote><div class="flex items-center mt-4"><svg width="15" height="15"><use xlink:href="#fc-lightbulb"></use></svg><span class="ml-2">Tip</span></div><p>TIP 123</p>

--- a/src/api/markdown-parser/common/generate-heading-id-plugin.ts
+++ b/src/api/markdown-parser/common/generate-heading-id-plugin.ts
@@ -22,7 +22,7 @@ export default function generateHeadingId() {
           idBuilder.push(child.value)
         }
       }
-      Object.assign(node.properties, { id: encodeURI(idBuilder.join('-')) })
+      Object.assign(node.properties, { id: idBuilder.join('-').replaceAll(' ', '-') })
     })
   }
 }

--- a/src/api/markdown-parser/impl/mdx/components/CommonHeadingWithId.ts
+++ b/src/api/markdown-parser/impl/mdx/components/CommonHeadingWithId.ts
@@ -5,7 +5,7 @@ interface CommonHeadingWithIdProps {
 }
 
 function titleToId(title: string): string {
-  return encodeURI(title.replaceAll(' ', '-'))
+  return title.replaceAll(' ', '-')
 }
 
 const CommonHeadingWithId:React.FC<React.PropsWithChildren<CommonHeadingWithIdProps>> = props => {


### PR DESCRIPTION
浏览器会自动对 url 解码，导致无法找到 url 编码后的标题。